### PR TITLE
Back to using codespell default dictionaries

### DIFF
--- a/.codespell/ignore-words.txt
+++ b/.codespell/ignore-words.txt
@@ -1,8 +1,3 @@
-Chang
-Damon
-Forman
-Manuel
-Tim
 adaptee
 ancilliary
 ans
@@ -36,5 +31,4 @@ recuse
 reenable
 referencable
 therefor
-tim
 warmup


### PR DESCRIPTION
@hugovk We can just go back to defaults (which it was always until I added names and code) like this. Possibly better than me wasting your time on this!